### PR TITLE
Changing Populate to take an IRegistry instead of Registry

### DIFF
--- a/src/StructureMap.AspNetCore/WebHostBuilderExtensions.cs
+++ b/src/StructureMap.AspNetCore/WebHostBuilderExtensions.cs
@@ -9,7 +9,7 @@ namespace StructureMap.AspNetCore
             return UseStructureMap(builder, registry: null);
         }
 
-        public static IWebHostBuilder UseStructureMap(this IWebHostBuilder builder, Registry registry)
+        public static IWebHostBuilder UseStructureMap(this IWebHostBuilder builder, IRegistry registry)
         {
             return builder.ConfigureServices(services => services.AddStructureMap(registry));
         }

--- a/src/StructureMap.Microsoft.DependencyInjection/ContainerExtensions.cs
+++ b/src/StructureMap.Microsoft.DependencyInjection/ContainerExtensions.cs
@@ -23,19 +23,6 @@ namespace StructureMap
         }
 
         /// <summary>
-        /// Populates the container using the specified service descriptors.
-        /// </summary>
-        /// <remarks>
-        /// This method should only be called once per container.
-        /// </remarks>
-        /// <param name="config">The configuration.</param>
-        /// <param name="descriptors">The service descriptors.</param>
-        public static void Populate(this ConfigurationExpression config, IEnumerable<ServiceDescriptor> descriptors)
-        {
-            Populate((Registry) config, descriptors);
-        }
-
-        /// <summary>
         /// Populates the registry using the specified service descriptors.
         /// </summary>
         /// <remarks>
@@ -43,7 +30,7 @@ namespace StructureMap
         /// </remarks>
         /// <param name="registry">The registry.</param>
         /// <param name="descriptors">The service descriptors.</param>
-        public static void Populate(this Registry registry, IEnumerable<ServiceDescriptor> descriptors)
+        public static void Populate(this IRegistry registry, IEnumerable<ServiceDescriptor> descriptors)
         {
             // HACK: We insert this action in order to prevent Populate being called twice on the same container.
             registry.Configure(ThrowIfMarkerInterfaceIsRegistered);

--- a/src/StructureMap.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/StructureMap.Microsoft.DependencyInjection/ServiceCollectionExtensions.cs
@@ -9,9 +9,9 @@ namespace StructureMap
             return AddStructureMap(services, registry: null);
         }
 
-        public static IServiceCollection AddStructureMap(this IServiceCollection services, Registry registry)
+        public static IServiceCollection AddStructureMap(this IServiceCollection services, IRegistry registry)
         {
-            return services.AddSingleton<IServiceProviderFactory<Registry>>(new StructureMapServiceProviderFactory(registry));
+            return services.AddSingleton<IServiceProviderFactory<IRegistry>>(new StructureMapServiceProviderFactory(registry));
         }
     }
 }

--- a/src/StructureMap.Microsoft.DependencyInjection/StructureMapServiceProviderFactory.cs
+++ b/src/StructureMap.Microsoft.DependencyInjection/StructureMapServiceProviderFactory.cs
@@ -1,18 +1,19 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
+using StructureMap.Graph;
 
 namespace StructureMap
 {
-    public class StructureMapServiceProviderFactory : IServiceProviderFactory<Registry>
+    public class StructureMapServiceProviderFactory : IServiceProviderFactory<IRegistry>
     {
-        public StructureMapServiceProviderFactory(Registry registry)
+        public StructureMapServiceProviderFactory(IRegistry registry)
         {
             Registry = registry;
         }
 
-        private Registry Registry { get; }
+        private IRegistry Registry { get; }
 
-        public Registry CreateBuilder(IServiceCollection services)
+        public IRegistry CreateBuilder(IServiceCollection services)
         {
             var registry = Registry ?? new Registry();
 
@@ -21,7 +22,7 @@ namespace StructureMap
             return registry;
         }
 
-        public IServiceProvider CreateServiceProvider(Registry registry)
+        public IServiceProvider CreateServiceProvider(IRegistry registry)
         {
             var container = new Container(registry);
 

--- a/test/StructureMap.Microsoft.DependencyInjection.Tests/StructureMapContainerTests.cs
+++ b/test/StructureMap.Microsoft.DependencyInjection.Tests/StructureMapContainerTests.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Specification;
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
-using StructureMap.Graph;
 using Xunit;
 
 namespace StructureMap.Microsoft.DependencyInjection.Tests


### PR DESCRIPTION
And removing overload taking ```ConfigurationExpression```.

This is a breaking change, see #26 