### PR TITLE
Add missing 'using' directive in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ create a StructureMap `Registry` and optionally let the user configure it using 
 ```csharp
 using System.IO;
 using Microsoft.AspNetCore.Hosting;
+using StructureMap.AspNetCore;
 
 public class Program
 {


### PR DESCRIPTION
Added a 'using' line that enables the first code example to compile. Otherwise it won't recognise the UseStructureMap() extension method.