### PR TITLE
Exclude private and static constructors in constructor policy

### DIFF
--- a/src/StructureMap.Microsoft.DependencyInjection/AspNetConstructorSelector.cs
+++ b/src/StructureMap.Microsoft.DependencyInjection/AspNetConstructorSelector.cs
@@ -12,6 +12,7 @@ namespace StructureMap
         public ConstructorInfo Find(Type pluggedType, DependencyCollection dependencies, PluginGraph graph) =>
             pluggedType.GetTypeInfo()
                 .DeclaredConstructors
+                .Where(ctor => ctor.IsConstructor && !ctor.IsPrivate) // IsConstructor is false for static constructors
                 .Select(ctor => new { Constructor = ctor, Parameters = ctor.GetParameters() })
                 .Where(x => x.Parameters.All(param => graph.HasFamily(param.ParameterType) || dependencies.Any(dep => dep.Type == param.ParameterType)))
                 .OrderByDescending(x => x.Parameters.Length)


### PR DESCRIPTION
Closes https://github.com/structuremap/StructureMap.Microsoft.DependencyInjection/issues/30

Might want to upgrade project.json to csproj though, I had to migrate locally first as blessed sdks dropped that support quite some time ago already.