### PR TITLE
Replace TryGetInstance to GetInstance

### DIFF
--- a/src/StructureMap.Microsoft.DependencyInjection/StructureMapServiceProvider.cs
+++ b/src/StructureMap.Microsoft.DependencyInjection/StructureMapServiceProvider.cs
@@ -20,7 +20,14 @@ namespace StructureMap
         public object GetService(Type serviceType)
         {
             // TryGetInstance doesn't resolve instances of concrete types
-            return Container.GetInstance(serviceType);
+            try
+            {
+                return Container.GetInstance(serviceType);
+            }
+            catch (StructureMapConfigurationException)
+            {
+                return null;
+            }
         }
 
         public object GetRequiredService(Type serviceType)

--- a/src/StructureMap.Microsoft.DependencyInjection/StructureMapServiceProvider.cs
+++ b/src/StructureMap.Microsoft.DependencyInjection/StructureMapServiceProvider.cs
@@ -19,14 +19,8 @@ namespace StructureMap
 
         public object GetService(Type serviceType)
         {
-            if (serviceType.IsGenericEnumerable())
-            {
-                // Ideally we'd like to call TryGetInstance here as well,
-                // but StructureMap does't like it for some weird reason.
-                return GetRequiredService(serviceType);
-            }
-
-            return Container.TryGetInstance(serviceType);
+            // TryGetInstance doesn't resolve instances of concrete types
+            return Container.GetInstance(serviceType);
         }
 
         public object GetRequiredService(Type serviceType)

--- a/test/StructureMap.Microsoft.DependencyInjection.Tests/StructureMapServiceProviderTests.cs
+++ b/test/StructureMap.Microsoft.DependencyInjection.Tests/StructureMapServiceProviderTests.cs
@@ -24,6 +24,16 @@ namespace StructureMap.Microsoft.DependencyInjection.Tests
             Assert.IsType<BlueWidget>(provider.GetRequiredService(typeof(IWidget)));
         }
 
+        [Fact]
+        public void get_service_without_registered_types_return_null()
+        {
+            var root = new Container();
+            
+            var provider = new StructureMapServiceProvider(root);
+            Assert.Same(provider.Container, root);
+            Assert.Null(provider.GetService(typeof(IWidget)));
+        }
+
         public interface IWidget { }
 
         public class BlueWidget : IWidget { }


### PR DESCRIPTION
Sometimes we use concrete classes and `StructureMapServiceProvider.GetInstance()` doesn't resolve instances.
But `GetInstance` can resolve it - [Auto Resolving Concrete Types](https://structuremap.github.io/resolving/requesting-a-concrete-type/)

Might want to accept changes