### PR TITLE
Add missing Dispose on StructureMapServiceProvider

### DIFF
--- a/src/StructureMap.Microsoft.DependencyInjection/StructureMapServiceProvider.cs
+++ b/src/StructureMap.Microsoft.DependencyInjection/StructureMapServiceProvider.cs
@@ -4,9 +4,10 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace StructureMap
 {
-    public sealed class StructureMapServiceProvider : IServiceProvider, ISupportRequiredService
+    public sealed class StructureMapServiceProvider : IServiceProvider, ISupportRequiredService, IDisposable
     {
         private readonly Stack<IContainer> _containers = new Stack<IContainer>();
+        private bool _isDisposing = false;
 
         public StructureMapServiceProvider(IContainer container)
         {
@@ -52,6 +53,21 @@ namespace StructureMap
             {
                 var child = _containers.Pop();
                 child.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposing)
+            {
+                return;
+            }
+
+            _isDisposing = true;
+
+            foreach (var container in _containers)
+            {
+                container.Dispose();
             }
         }
     }


### PR DESCRIPTION
This fixes a hang if disposable resources are registered through Structuremap, such as StackExchange.Redis which manages its own threads.

Called here: https://github.com/dotnet/aspnetcore/blob/master/src/Hosting/Hosting/src/Internal/WebHost.cs#L382-L393

![Screen Shot 2020-11-09 at 15 42 35](https://user-images.githubusercontent.com/942358/98594265-69341780-22a2-11eb-8312-8d8ba9dc6141.png)
![Screen Shot 2020-11-09 at 15 42 24](https://user-images.githubusercontent.com/942358/98594275-6cc79e80-22a2-11eb-9b77-1dd52ef6fffa.png)
