### PR TITLE
Added HostBuilderExtensions

### DIFF
--- a/StructureMap.Microsoft.DependencyInjection.sln
+++ b/StructureMap.Microsoft.DependencyInjection.sln
@@ -26,7 +26,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StructureMap.Microsoft.Depe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StructureMap.AspNetCore", "src\StructureMap.AspNetCore\StructureMap.AspNetCore.csproj", "{6B38D654-FE83-4594-B99B-E73F117DDCE6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StructureMap.AspNetCore.Sample", "sample\StructureMap.AspNetCore.Sample\StructureMap.AspNetCore.Sample.csproj", "{7A42E6D6-0199-41EC-8612-B1700961135C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StructureMap.AspNetCore.Sample", "sample\StructureMap.AspNetCore.Sample\StructureMap.AspNetCore.Sample.csproj", "{7A42E6D6-0199-41EC-8612-B1700961135C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StructureMap.AspNetCoreV2", "src\StructureMap.AspNetCoreV2\StructureMap.AspNetCoreV2.csproj", "{AAC5FD5D-4EB9-4E03-9075-D69FB95AD33C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StructureMap.AspNetCoreV2.Sample", "sample\StructureMap.AspNetCoreV2.Sample\StructureMap.AspNetCoreV2.Sample.csproj", "{0CF3D0C7-3144-435B-A249-D56B9EE61420}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -50,6 +54,14 @@ Global
 		{7A42E6D6-0199-41EC-8612-B1700961135C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7A42E6D6-0199-41EC-8612-B1700961135C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7A42E6D6-0199-41EC-8612-B1700961135C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AAC5FD5D-4EB9-4E03-9075-D69FB95AD33C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAC5FD5D-4EB9-4E03-9075-D69FB95AD33C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AAC5FD5D-4EB9-4E03-9075-D69FB95AD33C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AAC5FD5D-4EB9-4E03-9075-D69FB95AD33C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0CF3D0C7-3144-435B-A249-D56B9EE61420}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0CF3D0C7-3144-435B-A249-D56B9EE61420}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0CF3D0C7-3144-435B-A249-D56B9EE61420}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0CF3D0C7-3144-435B-A249-D56B9EE61420}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -59,6 +71,8 @@ Global
 		{2B3D64C5-CA4D-41E5-AF3A-BA90AB80EB60} = {8037CE7A-020C-48D2-9C7E-BBEB669E19D7}
 		{6B38D654-FE83-4594-B99B-E73F117DDCE6} = {1AAD948C-6BBE-4334-BFF2-AA5F16F63845}
 		{7A42E6D6-0199-41EC-8612-B1700961135C} = {5C06EB0A-91A1-4FA1-801C-ABEDAEDBF87B}
+		{AAC5FD5D-4EB9-4E03-9075-D69FB95AD33C} = {1AAD948C-6BBE-4334-BFF2-AA5F16F63845}
+		{0CF3D0C7-3144-435B-A249-D56B9EE61420} = {5C06EB0A-91A1-4FA1-801C-ABEDAEDBF87B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B31A59D6-59DC-47FD-9B37-D6F28BEBB184}

--- a/sample/StructureMap.AspNetCoreV2.Sample/ILogger.cs
+++ b/sample/StructureMap.AspNetCoreV2.Sample/ILogger.cs
@@ -1,0 +1,7 @@
+﻿namespace StructureMap.AspNetCoreV2.Sample
+{
+    public interface ILogger
+    {
+        void Info(string message, params object[] args);
+    }
+}

--- a/sample/StructureMap.AspNetCoreV2.Sample/Logger.cs
+++ b/sample/StructureMap.AspNetCoreV2.Sample/Logger.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace StructureMap.AspNetCoreV2.Sample
+{
+    public class ConsoleLogger : ILogger
+    {
+        public void Info(string message, params object[] args)
+        {
+            Console.WriteLine(message, args);
+        }
+    }
+}

--- a/sample/StructureMap.AspNetCoreV2.Sample/Program.cs
+++ b/sample/StructureMap.AspNetCoreV2.Sample/Program.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace StructureMap.AspNetCoreV2.Sample
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .UseStructureMap() // Add support for StructureMap
+                .ConfigureContainer<Registry>((hostContext, container) =>
+                {
+                    // Use this method to add services, using StructureMap-specific APIs.
+                    container.For<ILogger>().Use<ConsoleLogger>();
+                })
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddHostedService<Worker>();
+                });
+    }
+}

--- a/sample/StructureMap.AspNetCoreV2.Sample/StructureMap.AspNetCoreV2.Sample.csproj
+++ b/sample/StructureMap.AspNetCoreV2.Sample/StructureMap.AspNetCoreV2.Sample.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.11" />
+    <PackageReference Include="StructureMap" Version="4.7.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\StructureMap.AspNetCoreV2\StructureMap.AspNetCoreV2.csproj" />
+  </ItemGroup>
+</Project>

--- a/sample/StructureMap.AspNetCoreV2.Sample/Worker.cs
+++ b/sample/StructureMap.AspNetCoreV2.Sample/Worker.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+namespace StructureMap.AspNetCoreV2.Sample
+{
+    class Worker : BackgroundService
+    {
+        private readonly ILogger _logger;
+
+        public Worker(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            _logger.Info("Worker is starting.");
+            stoppingToken.Register(() => _logger.Info("Worker is stopping."));
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                _logger.Info("Worker running at: {0}", DateTime.UtcNow);
+                await Task.Delay(1000, stoppingToken);
+            }
+
+            _logger.Info("Worker background task is stopping.");
+        }
+    }
+}

--- a/src/StructureMap.AspNetCoreV2/HostBuilderExtensions.cs
+++ b/src/StructureMap.AspNetCoreV2/HostBuilderExtensions.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Extensions.Hosting;
+
+namespace StructureMap.AspNetCoreV2
+{
+    public static class HostBuilderExtensions
+    {
+        public static IHostBuilder UseStructureMap(this IHostBuilder builder)
+        {
+            return UseStructureMap(builder, registry: null);
+        }
+
+        public static IHostBuilder UseStructureMap(this IHostBuilder builder, Registry registry)
+        {
+            return builder.UseServiceProviderFactory(new StructureMapServiceProviderFactory(registry));
+        }
+    }
+}

--- a/src/StructureMap.AspNetCoreV2/StructureMap.AspNetCoreV2.csproj
+++ b/src/StructureMap.AspNetCoreV2/StructureMap.AspNetCoreV2.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>StructureMap.AspNetCoreV2</Description>
+    <PackageTags>$(PackageTags);AspNetCore</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\StructureMap.Microsoft.DependencyInjection\StructureMap.Microsoft.DependencyInjection.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
I would like to add extensions methods for the IHostBuilder to make this library work with [Generic Host](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-2.1) introduced in ASP.NET Core 2.1.
It allows us to run [background tasks with hosted services](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-2.1) in [console applications](https://docs.microsoft.com/en-us/dotnet/architecture/microservices/multi-container-microservice-net-applications/background-tasks-with-ihostedservice).

